### PR TITLE
Fix ui description issues

### DIFF
--- a/frontend/src/routes/library.tsx
+++ b/frontend/src/routes/library.tsx
@@ -304,7 +304,9 @@ export default function Library() {
                         <h3 className="font-semibold text-gray-900 text-sm sm:text-base line-clamp-2 break-words pr-2">
                           {podcast.title}
                         </h3>
-                        <p className="text-sm text-gray-600 line-clamp-2 break-words">{stripAndTruncate(podcast.description, 150)}</p>
+                        <p className="text-sm text-gray-600 line-clamp-2 break-words">
+                          {stripAndTruncate(podcast.description, 150)}
+                        </p>
                         <div className="flex items-center space-x-4 mt-1 text-xs text-gray-500">
                           <span>{podcast.episodeCount} episodes</span>
                           <span>Added {new Date(podcast.createdAt).toLocaleDateString()}</span>

--- a/frontend/src/routes/library.tsx
+++ b/frontend/src/routes/library.tsx
@@ -6,6 +6,7 @@ import { episodeService, Episode } from '../services/episodeService'
 import { APIError } from '../services/api'
 import { useAuth } from '../context/AuthContext'
 import { useMediaPlayer } from '../context/MediaPlayerContext'
+import { stripAndTruncate } from '../utils/textUtils'
 
 // Import the Episode type from MediaPlayerContext to avoid confusion
 type MediaPlayerEpisode = {
@@ -303,7 +304,7 @@ export default function Library() {
                         <h3 className="font-semibold text-gray-900 text-sm sm:text-base line-clamp-2 break-words pr-2">
                           {podcast.title}
                         </h3>
-                        <p className="text-sm text-gray-600 line-clamp-2 break-words">{podcast.description}</p>
+                        <p className="text-sm text-gray-600 line-clamp-2 break-words">{stripAndTruncate(podcast.description, 150)}</p>
                         <div className="flex items-center space-x-4 mt-1 text-xs text-gray-500">
                           <span>{podcast.episodeCount} episodes</span>
                           <span>Added {new Date(podcast.createdAt).toLocaleDateString()}</span>

--- a/frontend/src/utils/textUtils.ts
+++ b/frontend/src/utils/textUtils.ts
@@ -1,0 +1,41 @@
+/**
+ * Strips HTML tags from a string and returns clean text
+ * @param html The HTML string to clean
+ * @returns The cleaned text without HTML tags
+ */
+export function stripHtml(html: string): string {
+  if (!html) return ''
+
+  // Create a temporary DOM element to parse HTML
+  const tempDiv = document.createElement('div')
+  tempDiv.innerHTML = html
+
+  // Get text content and clean up extra whitespace
+  const textContent = tempDiv.textContent || tempDiv.innerText || ''
+
+  // Remove extra whitespace and normalize
+  return textContent.replace(/\s+/g, ' ').trim()
+}
+
+/**
+ * Truncates text to a specified length and adds ellipsis if needed
+ * @param text The text to truncate
+ * @param maxLength The maximum length of the text
+ * @returns The truncated text with ellipsis if needed
+ */
+export function truncateText(text: string, maxLength: number): string {
+  if (!text || text.length <= maxLength) return text
+
+  return text.substring(0, maxLength).trim() + '...'
+}
+
+/**
+ * Strips HTML tags and truncates text in one function
+ * @param html The HTML string to clean and truncate
+ * @param maxLength The maximum length of the final text
+ * @returns The cleaned and truncated text
+ */
+export function stripAndTruncate(html: string, maxLength: number): string {
+  const cleanText = stripHtml(html)
+  return truncateText(cleanText, maxLength)
+}


### PR DESCRIPTION
Strip HTML and truncate podcast descriptions to fix UI layout issues.

Podcast descriptions containing HTML tags were being rendered as raw text, causing layout problems in the Library page. This change ensures descriptions are clean, truncated, and fit within the UI.