### PR TITLE
Investigate missing episode card thumbnails

### DIFF
--- a/BASIC_TESTS_SUMMARY.md
+++ b/BASIC_TESTS_SUMMARY.md
@@ -11,6 +11,7 @@ This document summarizes the basic tests implemented to ensure the PWA (Progress
 **Purpose**: Validates that core PWA functionality can be imported and instantiated without errors.
 
 **Coverage**:
+
 - PWA service import validation
 - PWA service instance creation
 - Method availability verification
@@ -18,6 +19,7 @@ This document summarizes the basic tests implemented to ensure the PWA (Progress
 - Type exports validation
 
 **Key Tests**:
+
 ```typescript
 - should import PWA service without throwing
 - should create PWA service instance without throwing
@@ -31,6 +33,7 @@ This document summarizes the basic tests implemented to ensure the PWA (Progress
 **Purpose**: Tests the PWA service functionality with proper mocking to ensure robust error handling.
 
 **Coverage**:
+
 - Service instantiation
 - Method availability
 - Basic functionality execution
@@ -38,6 +41,7 @@ This document summarizes the basic tests implemented to ensure the PWA (Progress
 - Graceful degradation in unsupported environments
 
 **Key Test Areas**:
+
 - **Basic Functionality**: Tests all public methods exist and execute without throwing
 - **Error Handling**: Validates graceful handling of missing browser APIs
 - **Environment Compatibility**: Tests behavior in environments without service worker or notification support
@@ -59,6 +63,7 @@ This document summarizes the basic tests implemented to ensure the PWA (Progress
 ### PWA Service (`frontend/src/services/pwaService.ts`)
 
 **Core Features Tested**:
+
 - Service worker registration and management
 - Update detection and notification system
 - Skip waiting functionality for immediate updates
@@ -67,6 +72,7 @@ This document summarizes the basic tests implemented to ensure the PWA (Progress
 - Error handling for unsupported environments
 
 **Browser API Compatibility**:
+
 - Works with or without service worker support
 - Handles missing notification API gracefully
 - Degrades gracefully in older browsers
@@ -74,6 +80,7 @@ This document summarizes the basic tests implemented to ensure the PWA (Progress
 ### Vite PWA Configuration (`frontend/vite.config.ts`)
 
 **Configuration Validated**:
+
 - `registerType: 'prompt'` for custom update handling
 - `skipWaiting: true` for immediate updates
 - `clientsClaim: true` for immediate control
@@ -83,6 +90,7 @@ This document summarizes the basic tests implemented to ensure the PWA (Progress
 ### Main Application Integration (`frontend/src/main.tsx`)
 
 **Integration Tested**:
+
 - PWA service initialization
 - Update notification callback setup
 - DOM manipulation for update UI
@@ -91,17 +99,20 @@ This document summarizes the basic tests implemented to ensure the PWA (Progress
 ## Build Validation
 
 ### Linting
+
 - **Status**: ✅ Passing
 - **Warnings**: Only TypeScript version warning (non-blocking)
 - **Errors**: 0 errors
 
 ### Testing
+
 - **Test Files**: 4 passed
 - **Total Tests**: 41 passed
 - **Duration**: ~1.3 seconds
 - **Coverage**: Core PWA functionality and existing features
 
 ### TypeScript Compilation
+
 - **Status**: ✅ Passing
 - **Type Safety**: All PWA types properly handled
 - **Import/Export**: All modules resolve correctly
@@ -111,11 +122,13 @@ This document summarizes the basic tests implemented to ensure the PWA (Progress
 The implementation is tested to work across different environments:
 
 ### ✅ Supported Browsers
+
 - Chrome/Edge (full PWA support)
 - Firefox (service worker support)
 - Safari (basic PWA support)
 
 ### ✅ Graceful Degradation
+
 - Browsers without service worker support
 - Environments without notification API
 - Older browsers with limited PWA features
@@ -132,6 +145,7 @@ The tests ensure:
 ## Maintenance Guidelines
 
 ### Running Tests
+
 ```bash
 # Run all tests
 npm test
@@ -144,6 +158,7 @@ npm test basic-build.test.ts
 ```
 
 ### Linting
+
 ```bash
 # Check for issues
 npm run lint
@@ -153,6 +168,7 @@ npm run lint:fix
 ```
 
 ### Build Verification
+
 ```bash
 # Build for production
 npm run build

--- a/PWA_UPDATE_IMPLEMENTATION.md
+++ b/PWA_UPDATE_IMPLEMENTATION.md
@@ -17,6 +17,7 @@ The `PWAService` class handles all PWA-related functionality including:
 - **Installation Detection**: Detects if app is installed as PWA
 
 **Key Features:**
+
 - Automatic update checking every 30 seconds
 - Skip waiting functionality to force immediate updates
 - Native notification support for background updates
@@ -51,6 +52,7 @@ VitePWA({
 ```
 
 **Key Settings:**
+
 - `registerType: 'prompt'`: Allows custom update handling
 - `skipWaiting: true`: New service worker takes control immediately
 - `clientsClaim: true`: New service worker claims all clients
@@ -88,12 +90,14 @@ The implementation supports multiple notification methods:
 ## Benefits
 
 ### For Users
+
 - **Immediate Updates**: Users get the latest features and bug fixes quickly
 - **No App Store**: Updates happen instantly without app store approval
 - **Offline Support**: App works offline with cached content
 - **Native Experience**: Feels like a native app when installed
 
 ### For Developers
+
 - **Instant Deployment**: Changes are live immediately after deployment
 - **No Version Fragmentation**: All users get updates quickly
 - **Better User Experience**: Seamless update process
@@ -250,6 +254,7 @@ expiration: {
 This implementation provides a robust, user-friendly way to handle PWA updates. Users get immediate access to new features while maintaining full control over when updates are applied. The system is designed to be reliable, performant, and easy to maintain.
 
 The key to success is the combination of:
+
 - Automatic background update detection
 - User-friendly notification system
 - Immediate update application

--- a/SMOKE_TESTS_SUMMARY.md
+++ b/SMOKE_TESTS_SUMMARY.md
@@ -1,11 +1,12 @@
 # Smoke Tests and Lint Summary
 
 ## Overview
+
 This document summarizes the basic smoke tests and lint results for the Rewind project after implementing the following changes:
 
 1. Episode cards now show either episode thumbnail or podcast thumbnail as fallback
 2. Media player (both expanded and mini) uses episode or podcast thumbnail
-3. Episode count displays total podcast episodes instead of loaded episodes  
+3. Episode count displays total podcast episodes instead of loaded episodes
 4. Removed redundant X close icon from expanded player
 5. Removed user name display from header when logged in
 
@@ -14,6 +15,7 @@ This document summarizes the basic smoke tests and lint results for the Rewind p
 ### ✅ Passing Tests (101 passing)
 
 #### Component Tests
+
 - **EpisodeCard.test.tsx** (15 tests) - All passing
   - Basic rendering and functionality
   - Image fallback behavior (episode → podcast → placeholder)
@@ -21,7 +23,8 @@ This document summarizes the basic smoke tests and lint results for the Rewind p
   - Progress indicator functionality
   - AI explanation button
 
-#### Route Tests  
+#### Route Tests
+
 - **home.test.tsx** (11 tests) - All passing
   - Page rendering and structure
   - Sample episode display
@@ -35,6 +38,7 @@ This document summarizes the basic smoke tests and lint results for the Rewind p
   - Basic UI structure
 
 #### Component Structure Tests
+
 - **Header.test.tsx** (8 tests) - All passing
   - Authentication UI states
   - Menu functionality
@@ -42,30 +46,37 @@ This document summarizes the basic smoke tests and lint results for the Rewind p
   - Logout button behavior
 
 #### Service Tests
+
 - **pwaService.test.ts** (12 tests) - All passing
 - **episodeService.test.ts** (13 tests) - All passing
 - **podcastService.test.ts** (6 tests) - All passing
 
 #### Utility Tests
+
 - **textUtils.test.ts** (10 tests) - All passing
 
 #### Basic Build Tests
+
 - **basic-build.test.ts** (5 tests) - All passing
 
 #### Smoke Tests
+
 - **smoke-tests.test.ts** (18 tests) - 15 passing, 3 failing
 
 ### ❌ Failing Tests (14 failing)
 
 #### FloatingMediaPlayer Tests (11 failing)
+
 **Issue**: `MediaMetadata is not defined` in test environment
+
 - Tests fail because the browser MediaSession API is not available in jsdom
 - The component itself works correctly in the browser
 - All functionality tests fail due to this environmental issue
 
 **Tests affected**:
+
 - renders mini player when episode is provided
-- shows episode image when available  
+- shows episode image when available
 - shows podcast image when episode image is not available
 - calls onPlay when play button is clicked
 - calls onPause when pause button is clicked
@@ -77,6 +88,7 @@ This document summarizes the basic smoke tests and lint results for the Rewind p
 - shows skip controls in expanded view
 
 #### Smoke Test Issues (3 failing)
+
 1. **MediaPlayerContext hook test** - Expected error message mismatch
 2. **EpisodeCard instantiation test** - React hooks outside component context
 3. **FloatingMediaPlayer instantiation test** - React hooks outside component context
@@ -84,6 +96,7 @@ This document summarizes the basic smoke tests and lint results for the Rewind p
 ## Lint Results
 
 ### ✅ All Lint Issues Fixed
+
 - **140 lint errors** were automatically fixed using `eslint --fix`
 - Issues included:
   - Trailing spaces
@@ -91,6 +104,7 @@ This document summarizes the basic smoke tests and lint results for the Rewind p
   - Missing newlines at end of files
 
 ### Current Status
+
 - No lint errors remaining
 - All code follows project style guidelines
 - TypeScript compilation successful
@@ -98,30 +112,40 @@ This document summarizes the basic smoke tests and lint results for the Rewind p
 ## Key Changes Tested
 
 ### 1. Episode/Podcast Thumbnail Fallback
+
 **Status**: ✅ Fully tested and working
+
 - EpisodeCard component now accepts `podcastImageUrl` prop
 - Image display logic: episode.imageUrl → podcastImageUrl → placeholder
 - Tests verify priority and fallback behavior
 
-### 2. Media Player Thumbnail Support  
+### 2. Media Player Thumbnail Support
+
 **Status**: ⚠️ Functionality implemented, tests failing due to environment
+
 - Both mini and expanded player support episode/podcast thumbnails
 - MediaPlayerContext updated with `podcastImageUrl` field
 - Component works in browser but tests fail due to MediaMetadata API
 
 ### 3. Episode Count Display
+
 **Status**: ✅ Fully tested and working
+
 - Podcast detail page shows `podcast.episodeCount` instead of `episodes.length`
 - Displays total available episodes rather than currently loaded episodes
 
 ### 4. Removed Redundant Close Button
+
 **Status**: ⚠️ Functionality implemented, tests failing due to environment
+
 - X close button removed from expanded player header
 - Only minimize button remains in expanded view
 - Test verifies absence of close button but fails due to MediaMetadata issue
 
 ### 5. User Name Removal from Header
+
 **Status**: ✅ Fully tested and working
+
 - User name no longer displayed when logged in
 - Only logout button shown for authenticated users
 - Tests verify the change is implemented correctly
@@ -129,9 +153,11 @@ This document summarizes the basic smoke tests and lint results for the Rewind p
 ## Recommendations
 
 ### Test Environment Fixes Needed
+
 1. **Mock MediaMetadata API** in test setup
+
    ```javascript
-   global.MediaMetadata = vi.fn().mockImplementation((metadata) => metadata)
+   global.MediaMetadata = vi.fn().mockImplementation(metadata => metadata)
    ```
 
 2. **Mock MediaSession API** more completely
@@ -141,12 +167,13 @@ This document summarizes the basic smoke tests and lint results for the Rewind p
        mediaSession: {
          metadata: null,
          setActionHandler: vi.fn(),
-       }
-     }
+       },
+     },
    })
    ```
 
 ### Component Testing Strategy
+
 - Focus on unit tests for individual component logic
 - Use integration tests for MediaSession API functionality
 - Consider using Playwright for browser-based testing of media features
@@ -156,7 +183,7 @@ This document summarizes the basic smoke tests and lint results for the Rewind p
 **Overall Status**: ✅ Implementation Successful
 
 - **Features**: All requested changes implemented correctly
-- **Functionality**: Components work as expected in browser environment  
+- **Functionality**: Components work as expected in browser environment
 - **Code Quality**: All lint issues resolved, follows project standards
 - **Test Coverage**: 88% of tests passing (101/115)
 - **Remaining Issues**: Test environment limitations, not functionality bugs

--- a/TEST_SUMMARY.md
+++ b/TEST_SUMMARY.md
@@ -3,9 +3,11 @@
 ## ✅ Successfully Implemented Basic Tests to Prevent Build Issues
 
 ### Overview
+
 I've created comprehensive unit tests for the Rewind project's frontend to ensure core functionality works and prevent build issues. The tests are **running successfully** with Vitest and React Testing Library.
 
 ## Test Results Summary
+
 - **42 tests passed** ✅
 - **0 tests failed** ✅
 - **No build-breaking errors** ✅
@@ -14,7 +16,9 @@ I've created comprehensive unit tests for the Rewind project's frontend to ensur
 ## Tests Created
 
 ### 1. **PodcastDetail Component Tests** (`src/routes/__tests__/podcast-detail.test.tsx`)
+
 **Purpose:** Test the new podcast detail page functionality
+
 - ✅ Component renders without crashing
 - ✅ Displays podcast information correctly
 - ✅ Handles navigation (back button)
@@ -25,7 +29,9 @@ I've created comprehensive unit tests for the Rewind project's frontend to ensur
 - ✅ Authentication flow
 
 ### 2. **Library Component Tests** (`src/routes/__tests__/library.test.tsx`)
+
 **Purpose:** Test the updated library page with navigation
+
 - ✅ Component renders without crashing
 - ✅ Shows loading states
 - ✅ Displays empty states
@@ -33,7 +39,9 @@ I've created comprehensive unit tests for the Rewind project's frontend to ensur
 - ✅ Authentication integration
 
 ### 3. **PodcastService Tests** (`src/services/__tests__/podcastService.test.ts`)
+
 **Purpose:** Test podcast API service functionality
+
 - ✅ Fetches podcasts successfully
 - ✅ Adds podcasts with proper request format
 - ✅ Deletes podcasts
@@ -41,7 +49,9 @@ I've created comprehensive unit tests for the Rewind project's frontend to ensur
 - ✅ Service instantiation and method calls
 
 ### 4. **EpisodeService Tests** (`src/services/__tests__/episodeService.test.ts`)
+
 **Purpose:** Test episode API service functionality
+
 - ✅ Fetches episodes with pagination
 - ✅ Syncs episodes from RSS feeds
 - ✅ Saves and retrieves playback progress
@@ -50,7 +60,9 @@ I've created comprehensive unit tests for the Rewind project's frontend to ensur
 - ✅ API error handling
 
 ### 5. **TextUtils Tests** (`src/utils/__tests__/textUtils.test.ts`)
+
 **Purpose:** Test text processing utilities
+
 - ✅ HTML stripping functionality
 - ✅ Text truncation
 - ✅ Entity decoding
@@ -60,19 +72,22 @@ I've created comprehensive unit tests for the Rewind project's frontend to ensur
 ## Key Benefits
 
 ### 🔒 **Prevents Build Issues**
+
 - **Components render without crashing** - catches JSX/React errors
-- **Service calls work correctly** - prevents API integration issues  
+- **Service calls work correctly** - prevents API integration issues
 - **Imports resolve properly** - catches missing dependencies
 - **TypeScript compilation works** - ensures type safety
 
 ### 🛡️ **Catches Common Problems**
+
 - **Authentication flow issues**
-- **Navigation problems** 
+- **Navigation problems**
 - **API service failures**
 - **Component prop issues**
 - **State management errors**
 
 ### 🧪 **Testing Infrastructure**
+
 - **Vitest** configured and working
 - **React Testing Library** setup
 - **Mocking** for services and contexts
@@ -82,6 +97,7 @@ I've created comprehensive unit tests for the Rewind project's frontend to ensur
 ## Test Configuration
 
 ### ✅ **Working Setup:**
+
 - **Vitest** - Modern testing framework
 - **React Testing Library** - Component testing
 - **jsdom** - Browser environment simulation
@@ -89,6 +105,7 @@ I've created comprehensive unit tests for the Rewind project's frontend to ensur
 - **Coverage reporting** configured
 
 ### 📁 **Test File Structure:**
+
 ```
 frontend/src/
 ├── routes/__tests__/
@@ -127,6 +144,7 @@ All test issues have been resolved:
 ## Conclusion
 
 ✅ **Mission Accomplished:** The tests successfully prevent build issues by:
+
 - Ensuring components render without errors
 - Validating service integrations work
 - Catching import/dependency problems

--- a/frontend/src/routes/podcast-detail.tsx
+++ b/frontend/src/routes/podcast-detail.tsx
@@ -176,6 +176,7 @@ export default function PodcastDetail() {
       audioUrl: episode.audioUrl,
       imageUrl: episode.imageUrl,
       description: episode.description,
+      podcastImageUrl: podcast?.imageUrl,
     }
   }
 


### PR DESCRIPTION
Add podcast image URL as a fallback for episode card thumbnails.

Previously, episode cards would display a blank placeholder if an episode did not have its own `imageUrl`. This change ensures that the `EpisodeCard` component receives the `podcastImageUrl` as a fallback, allowing it to display the podcast's artwork when an episode-specific image is absent.