### PR TITLE
Fix AWS_REGION environment variable error

### DIFF
--- a/backend/src/handlers/authHandler.ts
+++ b/backend/src/handlers/authHandler.ts
@@ -12,8 +12,8 @@ import { marshall } from '@aws-sdk/util-dynamodb'
 import { createResponse } from '../utils/response'
 import { User } from '../types'
 
-const cognitoClient = new CognitoIdentityProviderClient({ region: process.env.AWS_REGION })
-const dynamoClient = new DynamoDBClient({ region: process.env.AWS_REGION })
+const cognitoClient = new CognitoIdentityProviderClient({ region: process.env.AWS_REGION || 'us-east-1' })
+const dynamoClient = new DynamoDBClient({ region: process.env.AWS_REGION || 'us-east-1' })
 
 const USER_POOL_CLIENT_ID = process.env.USER_POOL_CLIENT_ID!
 const USERS_TABLE = process.env.USERS_TABLE!

--- a/backend/src/services/dynamoService.ts
+++ b/backend/src/services/dynamoService.ts
@@ -9,7 +9,7 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { Podcast, Episode, EpisodeData, ListeningHistoryItem } from '../types'
 import { v4 as uuidv4 } from 'uuid'
 
-const dynamoClient = new DynamoDBClient({ region: process.env.AWS_REGION })
+const dynamoClient = new DynamoDBClient({ region: process.env.AWS_REGION || 'us-east-1' })
 const PODCASTS_TABLE = process.env.PODCASTS_TABLE || 'RewindPodcasts'
 const EPISODES_TABLE = process.env.EPISODES_TABLE || 'RewindEpisodes'
 const LISTENING_HISTORY_TABLE = process.env.LISTENING_HISTORY_TABLE || 'RewindListeningHistory'

--- a/infra/lib/rewind-backend-stack.ts
+++ b/infra/lib/rewind-backend-stack.ts
@@ -95,7 +95,6 @@ export class RewindBackendStack extends cdk.Stack {
         GUEST_ANALYTICS_TABLE: props.tables.guestAnalytics.tableName,
         USER_FEEDBACK_TABLE: props.tables.userFeedback.tableName,
         PODCASTS_TABLE: props.tables.podcasts.tableName,
-        AWS_REGION: this.region,
       },
       timeout: cdk.Duration.seconds(30),
       memorySize: 1024, // More memory for AI processing


### PR DESCRIPTION
Fix CDK deployment error by removing reserved `AWS_REGION` environment variable and adding fallback regions to AWS SDK clients.

The `AWS_REGION` environment variable is reserved by the Lambda runtime and cannot be manually configured, leading to a `ValidationError` during CDK deployment. Removing this manual setting allows Lambda to automatically provide the region. Fallback regions were added to AWS SDK clients for robustness and consistency.