### PR TITLE
Check CDK update for new endpoint

### DIFF
--- a/backend/src/services/dynamoService.ts
+++ b/backend/src/services/dynamoService.ts
@@ -9,7 +9,6 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { Podcast, Episode, EpisodeData, ListeningHistoryItem } from '../types'
 import { v4 as uuidv4 } from 'uuid'
 
-
 const dynamoClient = new DynamoDBClient({ region: process.env.AWS_REGION || 'us-east-1' })
 const PODCASTS_TABLE = process.env.PODCASTS_TABLE || 'RewindPodcasts'
 const EPISODES_TABLE = process.env.EPISODES_TABLE || 'RewindEpisodes'

--- a/infra/lib/rewind-backend-stack.ts
+++ b/infra/lib/rewind-backend-stack.ts
@@ -239,6 +239,13 @@ export class RewindBackendStack extends cdk.Stack {
       authorizationType: apigateway.AuthorizationType.COGNITO,
     })
 
+    // POST /episodes/{podcastId}/fix-images - Fix episode image URLs
+    const fixImages = episodesByPodcast.addResource('fix-images')
+    fixImages.addMethod('POST', new apigateway.LambdaIntegration(episodeFunction), {
+      authorizer: cognitoAuthorizer,
+      authorizationType: apigateway.AuthorizationType.COGNITO,
+    })
+
     // Episode progress routes
     const episodeById = episodes.addResource('{episodeId}')
     const progress = episodeById.addResource('progress')


### PR DESCRIPTION
Add missing API Gateway route for `POST /episodes/{podcastId}/fix-images`.

The backend implementation for this endpoint was already complete, but the API Gateway route was not defined in the CDK, making the endpoint inaccessible.