### PR TITLE
Investigate deployment failure reasons

### DIFF
--- a/infra/lib/rewind-monitoring-stack.ts
+++ b/infra/lib/rewind-monitoring-stack.ts
@@ -75,7 +75,7 @@ export class RewindMonitoringStack extends cdk.Stack {
         telemetries: ['errors', 'performance', 'http'],
         identityPoolId: identityPool.ref,
         guestRoleArn: unauthenticatedRole.roleArn,
-        includedPages: ['*'],
+        includedPages: [`https://${props.domainName}/*`],
         excludedPages: [],
         favoritePages: ['/login', '/signup', '/', '/library'],
         metricDestinations: [


### PR DESCRIPTION
Fix AWS RUM AppMonitor configuration to resolve deployment failures.

The `includedPages` property in the RUM AppMonitor was set to `['*']`, which is not a valid pattern according to AWS RUM validation rules. This PR updates it to `https://${props.domainName}/*` to correctly track all pages under the CloudFront distribution.