### PR TITLE
Fix deployment issues for RewindMonitoringStack

### DIFF
--- a/infra/lib/rewind-backend-stack.ts
+++ b/infra/lib/rewind-backend-stack.ts
@@ -35,6 +35,10 @@ export class RewindBackendStack extends cdk.Stack {
       },
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,
+      bundling: {
+        forceDockerBundling: false,
+        externalModules: [],
+      },
     })
 
     // Create Lambda function for authentication operations
@@ -49,6 +53,10 @@ export class RewindBackendStack extends cdk.Stack {
       },
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,
+      bundling: {
+        forceDockerBundling: false,
+        externalModules: [],
+      },
     })
 
     // Create Lambda function for episode operations
@@ -63,6 +71,10 @@ export class RewindBackendStack extends cdk.Stack {
       },
       timeout: cdk.Duration.seconds(60), // Longer timeout for RSS parsing
       memorySize: 512, // More memory for episode processing
+      bundling: {
+        forceDockerBundling: false,
+        externalModules: [],
+      },
     })
 
     // Create Lambda function for recommendation operations
@@ -80,6 +92,10 @@ export class RewindBackendStack extends cdk.Stack {
       },
       timeout: cdk.Duration.seconds(30),
       memorySize: 1024, // More memory for AI processing
+      bundling: {
+        forceDockerBundling: false,
+        externalModules: [],
+      },
     })
 
     // Grant Bedrock permissions to recommendation function

--- a/infra/lib/rewind-monitoring-stack.ts
+++ b/infra/lib/rewind-monitoring-stack.ts
@@ -81,7 +81,6 @@ export class RewindMonitoringStack extends cdk.Stack {
         metricDestinations: [
           {
             destination: 'CloudWatch',
-            destinationArn: `arn:aws:logs:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:*`,
           },
         ],
       },


### PR DESCRIPTION
Fixes RUM AppMonitor deployment by correcting CloudWatch destination configuration and enables local bundling for Lambda functions.

The RUM AppMonitor failed to create with a `NotFound` error because the `destinationArn` was incorrectly specified for CloudWatch metric destinations. AWS RUM for CloudWatch does not require a specific ARN. Additionally, Lambda bundling was configured to use local bundling to avoid Docker dependency issues during deployment.