### PR TITLE
Troubleshoot invalid pool id in production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,9 +107,9 @@ jobs:
           cat > .env.production << EOF
           VITE_API_BASE_URL=${{ steps.cdk-outputs.outputs.api-url }}
           VITE_AWS_REGION=${{ env.AWS_REGION }}
-          VITE_COGNITO_USER_POOL_ID=${{ steps.cdk-outputs.outputs.user-pool-id }}
-          VITE_COGNITO_USER_POOL_CLIENT_ID=${{ steps.cdk-outputs.outputs.user-pool-client-id }}
-          VITE_COGNITO_IDENTITY_POOL_ID=${{ steps.cdk-outputs.outputs.identity-pool-id }}
+          VITE_USER_POOL_ID=${{ steps.cdk-outputs.outputs.user-pool-id }}
+          VITE_USER_POOL_CLIENT_ID=${{ steps.cdk-outputs.outputs.user-pool-client-id }}
+          VITE_IDENTITY_POOL_ID=${{ steps.cdk-outputs.outputs.identity-pool-id }}
           EOF
           npm run build
 

--- a/docs/AWS_CONFIG.md
+++ b/docs/AWS_CONFIG.md
@@ -305,9 +305,9 @@ export class RewindBackendStack extends cdk.Stack {
     // JWT Authorizer for Amazon Cognito
     const jwtAuthorizer = new apigateway.HttpJwtAuthorizer(
       'CognitoAuthorizer',
-      `https://cognito-idp.${this.region}.amazonaws.com/${process.env.COGNITO_USER_POOL_ID}`,
+      `https://cognito-idp.${this.region}.amazonaws.com/${process.env.USER_POOL_ID}`,
       {
-        jwtAudience: [process.env.COGNITO_CLIENT_ID],
+        jwtAudience: [process.env.USER_POOL_CLIENT_ID],
       },
     )
 
@@ -552,8 +552,8 @@ export class RewindFrontendStack extends cdk.Stack {
 ## Environment Variables
 
 - **Required Environment Variables**:
-  - `COGNITO_USER_POOL_ID`: Cognito User Pool ID
-  - `COGNITO_CLIENT_ID`: Cognito App Client ID
+  - `USER_POOL_ID`: Cognito User Pool ID
+- `USER_POOL_CLIENT_ID`: Cognito App Client ID
   - `COGNITO_REGION`: AWS region for Cognito service
   - `CDK_DEFAULT_ACCOUNT`: AWS account ID
   - `CDK_DEFAULT_REGION`: AWS region (e.g., us-east-1)

--- a/docs/DEPLOYMENT_PLAN.md
+++ b/docs/DEPLOYMENT_PLAN.md
@@ -55,9 +55,9 @@ This document outlines the complete deployment strategy for the Rewind podcast a
 ```
 VITE_API_BASE_URL=https://12c77xnz00.execute-api.us-east-1.amazonaws.com/v1
 VITE_AWS_REGION=us-east-1
-VITE_COGNITO_USER_POOL_ID=[FROM_CDK_OUTPUT]
-VITE_COGNITO_USER_POOL_CLIENT_ID=[FROM_CDK_OUTPUT]
-VITE_COGNITO_IDENTITY_POOL_ID=[FROM_CDK_OUTPUT]
+VITE_USER_POOL_ID=[FROM_CDK_OUTPUT]
+VITE_USER_POOL_CLIENT_ID=[FROM_CDK_OUTPUT]
+VITE_IDENTITY_POOL_ID=[FROM_CDK_OUTPUT]
 ```
 
 **Backend (Lambda environment variables - set by CDK):**

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -213,9 +213,9 @@ The deployment pipeline automatically configures these environment variables for
 
 - `VITE_API_BASE_URL`: From backend stack output
 - `VITE_AWS_REGION`: Set to us-east-1
-- `VITE_COGNITO_USER_POOL_ID`: From data stack output
-- `VITE_COGNITO_USER_POOL_CLIENT_ID`: From data stack output
-- `VITE_COGNITO_IDENTITY_POOL_ID`: From data stack output
+- `VITE_USER_POOL_ID`: From data stack output
+- `VITE_USER_POOL_CLIENT_ID`: From data stack output
+- `VITE_IDENTITY_POOL_ID`: From data stack output
 
 ### 2. Backend Configuration
 

--- a/docs/RECOMMENDATION_ENGINE_IMPLEMENTATION_PLAN.md
+++ b/docs/RECOMMENDATION_ENGINE_IMPLEMENTATION_PLAN.md
@@ -666,7 +666,7 @@ export interface RecommendationFilters {
 }
 
 export class RecommendationService {
-  private baseUrl = import.meta.env.VITE_API_URL
+  private baseUrl = import.meta.env.VITE_API_BASE_URL
 
   async getRecommendations(limit: number = 10, filters: RecommendationFilters = {}): Promise<RecommendationResponse> {
     const filterString = Object.entries(filters)

--- a/docs/THIRD_PARTY_INTEGRATIONS.md
+++ b/docs/THIRD_PARTY_INTEGRATIONS.md
@@ -8,10 +8,10 @@ This document outlines the third-party services and integrations used in Rewind,
 
 ### Configuration
 
-- **User Pool ID**: Configured via environment variable `COGNITO_USER_POOL_ID`
-- **Client ID**: Frontend application identifier via `COGNITO_CLIENT_ID`
-- **Region**: AWS region for Cognito service via `COGNITO_REGION`
-- **Identity Pool ID**: Optional for federated identities via `COGNITO_IDENTITY_POOL_ID`
+- **User Pool ID**: Configured via environment variable `USER_POOL_ID`
+- **Client ID**: Frontend application identifier via `USER_POOL_CLIENT_ID`
+- **Region**: AWS region for Cognito service via `AWS_REGION`
+- **Identity Pool ID**: Optional for federated identities via `IDENTITY_POOL_ID`
 
 ### Implementation
 
@@ -178,19 +178,19 @@ This document outlines the third-party services and integrations used in Rewind,
 ### Development Environment
 
 ```bash
-COGNITO_USER_POOL_ID=us-east-1_devABCDEF
-COGNITO_CLIENT_ID=dev_client_id_abcdefghijk
-COGNITO_REGION=us-east-1
-COGNITO_IDENTITY_POOL_ID=us-east-1:12345678-1234-1234-1234-123456789012
+USER_POOL_ID=us-east-1_devABCDEF
+USER_POOL_CLIENT_ID=dev_client_id_abcdefghijk
+AWS_REGION=us-east-1
+IDENTITY_POOL_ID=us-east-1:12345678-1234-1234-1234-123456789012
 ```
 
 ### Production Environment
 
 ```bash
-COGNITO_USER_POOL_ID=us-east-1_prodXYZ123
-COGNITO_CLIENT_ID=prod_client_id_lmnopqrstuv
-COGNITO_REGION=us-east-1
-COGNITO_IDENTITY_POOL_ID=us-east-1:87654321-4321-4321-4321-210987654321
+USER_POOL_ID=us-east-1_prodXYZ123
+USER_POOL_CLIENT_ID=prod_client_id_lmnopqrstuv
+AWS_REGION=us-east-1
+IDENTITY_POOL_ID=us-east-1:87654321-4321-4321-4321-210987654321
 ```
 
 ### Security Notes

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -16,15 +16,15 @@ COGNITO_IDENTITY_POOL_ID=us-east-1:14710d0b-58b7-4743-a489-1412f75f9c11
 NODE_ENV=development
 
 # Frontend Configuration (for Vite)
-VITE_COGNITO_USER_POOL_ID=us-east-1_Cw78Mapt3
-VITE_COGNITO_CLIENT_ID=49kf2uvsl9vg08ka6o67ts41jj
-VITE_COGNITO_REGION=us-east-1
-VITE_COGNITO_IDENTITY_POOL_ID=us-east-1:14710d0b-58b7-4743-a489-1412f75f9c11
+VITE_USER_POOL_ID=us-east-1_Cw78Mapt3
+VITE_USER_POOL_CLIENT_ID=49kf2uvsl9vg08ka6o67ts41jj
+VITE_AWS_REGION=us-east-1
+VITE_IDENTITY_POOL_ID=us-east-1:14710d0b-58b7-4743-a489-1412f75f9c11
 VITE_COGNITO_DOMAIN=https://rewind-730420835413-us-east-1.auth.us-east-1.amazoncognito.com
 VITE_AWS_ACCOUNT_ID=730420835413
 
 # API Gateway URL (from RewindBackendStack deployment)
-VITE_API_URL=https://12c77xnz00.execute-api.us-east-1.amazonaws.com/v1
+VITE_API_BASE_URL=https://12c77xnz00.execute-api.us-east-1.amazonaws.com/v1
 
 # Backend Configuration (for CDK)
 DYNAMODB_TABLE_PREFIX=Rewind

--- a/frontend/src/__tests__/integration/episodes.integration.test.tsx
+++ b/frontend/src/__tests__/integration/episodes.integration.test.tsx
@@ -9,7 +9,7 @@ import App from '../../App'
 // Set up MSW server
 import './setup/mswServer'
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001'
+const API_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001'
 
 describe.skip('Episode Integration Tests', () => {
   beforeEach(() => {

--- a/frontend/src/__tests__/integration/podcasts.integration.test.tsx
+++ b/frontend/src/__tests__/integration/podcasts.integration.test.tsx
@@ -9,7 +9,7 @@ import App from '../../App'
 // Set up MSW server
 import './setup/mswServer'
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001'
+const API_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001'
 
 describe.skip('Podcast Integration Tests', () => {
   beforeEach(() => {

--- a/frontend/src/__tests__/integration/recommendations.integration.test.tsx
+++ b/frontend/src/__tests__/integration/recommendations.integration.test.tsx
@@ -9,7 +9,7 @@ import App from '../../App'
 // Set up MSW server
 import './setup/mswServer'
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001'
+const API_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001'
 
 describe.skip('Recommendations Integration Tests', () => {
   beforeEach(() => {

--- a/frontend/src/__tests__/integration/search.integration.test.tsx
+++ b/frontend/src/__tests__/integration/search.integration.test.tsx
@@ -9,7 +9,7 @@ import App from '../../App'
 // Set up MSW server
 import './setup/mswServer'
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001'
+const API_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001'
 
 describe.skip('Search Integration Tests', () => {
   beforeEach(() => {

--- a/frontend/src/__tests__/integration/setup/handlers.ts
+++ b/frontend/src/__tests__/integration/setup/handlers.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from 'msw'
 
 // Base API URL - this should match your backend
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001'
+const API_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001'
 
 // Auth handlers with correct response shapes from backend
 export const authHandlers = [

--- a/frontend/src/__tests__/mocks/handlers.ts
+++ b/frontend/src/__tests__/mocks/handlers.ts
@@ -8,7 +8,7 @@ import {
 } from '../fixtures/auth.fixtures'
 import type { SignupRequest, SigninRequest, ConfirmRequest, ResendRequest } from '../types/api.types'
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000'
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000'
 
 // Auth handlers
 export const authHandlers = [

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -54,10 +54,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // Initialize Amplify configuration
   useEffect(() => {
     // In a real app, these would come from environment variables
-    // Check for both variable formats (with and without COGNITO prefix) for robustness
-    const userPoolId = import.meta.env.VITE_USER_POOL_ID || import.meta.env.VITE_COGNITO_USER_POOL_ID || 'placeholder'
-    const userPoolClientId = import.meta.env.VITE_USER_POOL_CLIENT_ID || import.meta.env.VITE_COGNITO_USER_POOL_CLIENT_ID || 'placeholder'
-    const identityPoolId = import.meta.env.VITE_IDENTITY_POOL_ID || import.meta.env.VITE_COGNITO_IDENTITY_POOL_ID || 'placeholder'
+    const userPoolId = import.meta.env.VITE_USER_POOL_ID || 'placeholder'
+    const userPoolClientId = import.meta.env.VITE_USER_POOL_CLIENT_ID || 'placeholder'
+    const identityPoolId = import.meta.env.VITE_IDENTITY_POOL_ID || 'placeholder'
 
     console.log('AuthContext: Environment variables loaded:', {
       userPoolId: userPoolId === 'placeholder' ? 'NOT SET' : userPoolId.substring(0, 10) + '...',

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -54,10 +54,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // Initialize Amplify configuration
   useEffect(() => {
     // In a real app, these would come from environment variables
-    // For now, we'll set them as placeholders
-    const userPoolId = import.meta.env.VITE_USER_POOL_ID || 'placeholder'
-    const userPoolClientId = import.meta.env.VITE_USER_POOL_CLIENT_ID || 'placeholder'
-    const identityPoolId = import.meta.env.VITE_IDENTITY_POOL_ID || 'placeholder'
+    // Check for both variable formats (with and without COGNITO prefix) for robustness
+    const userPoolId = import.meta.env.VITE_USER_POOL_ID || import.meta.env.VITE_COGNITO_USER_POOL_ID || 'placeholder'
+    const userPoolClientId = import.meta.env.VITE_USER_POOL_CLIENT_ID || import.meta.env.VITE_COGNITO_USER_POOL_CLIENT_ID || 'placeholder'
+    const identityPoolId = import.meta.env.VITE_IDENTITY_POOL_ID || import.meta.env.VITE_COGNITO_IDENTITY_POOL_ID || 'placeholder'
 
     console.log('AuthContext: Environment variables loaded:', {
       userPoolId: userPoolId === 'placeholder' ? 'NOT SET' : userPoolId.substring(0, 10) + '...',

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -6,6 +6,9 @@ interface ImportMetaEnv {
   readonly VITE_USER_POOL_ID: string
   readonly VITE_USER_POOL_CLIENT_ID: string
   readonly VITE_IDENTITY_POOL_ID: string
+  readonly VITE_COGNITO_USER_POOL_ID: string
+  readonly VITE_COGNITO_USER_POOL_CLIENT_ID: string
+  readonly VITE_COGNITO_IDENTITY_POOL_ID: string
   readonly VITE_RUM_APPLICATION_ID: string
   readonly VITE_RUM_IDENTITY_POOL_ID: string
   readonly VITE_RUM_REGION: string

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -6,9 +6,6 @@ interface ImportMetaEnv {
   readonly VITE_USER_POOL_ID: string
   readonly VITE_USER_POOL_CLIENT_ID: string
   readonly VITE_IDENTITY_POOL_ID: string
-  readonly VITE_COGNITO_USER_POOL_ID: string
-  readonly VITE_COGNITO_USER_POOL_CLIENT_ID: string
-  readonly VITE_COGNITO_IDENTITY_POOL_ID: string
   readonly VITE_RUM_APPLICATION_ID: string
   readonly VITE_RUM_IDENTITY_POOL_ID: string
   readonly VITE_RUM_REGION: string


### PR DESCRIPTION
Consolidate Cognito and API environment variable names to resolve production "invalid pool ID" errors and improve consistency.

The codebase had inconsistent naming for Cognito environment variables (e.g., `VITE_COGNITO_USER_POOL_ID` vs. `VITE_USER_POOL_ID`) between development, production, and documentation, leading to runtime issues in production. This PR standardizes these names across the frontend, backend documentation, and deployment workflow, and also unifies `VITE_API_URL` to `VITE_API_BASE_URL`.