### PR TITLE
Fix prod recommendations and search

### DIFF
--- a/backend/.cursor/rules/backend-development.mdc
+++ b/backend/.cursor/rules/backend-development.mdc
@@ -17,7 +17,7 @@ alwaysApply: false
 Reference [BACKEND_API.md](mdc:docs/BACKEND_API.md) for complete API documentation:
 
 ### Base URL
-- **Production**: `https://12c77xnz00.execute-api.us-east-1.amazonaws.com/v1`
+- **Production**: `https://bds33eqtv5.execute-api.us-east-1.amazonaws.com/prod`
 - **Development**: `https://12c77xnz00.execute-api.us-east-1.amazonaws.com/v1`
 
 ### Authentication

--- a/docs/BACKEND_API.md
+++ b/docs/BACKEND_API.md
@@ -6,7 +6,7 @@ This document outlines the RESTful API endpoints for the Rewind backend, support
 
 ## Base URL
 
-- **Production**: `https://12c77xnz00.execute-api.us-east-1.amazonaws.com/v1` ✅ DEPLOYED
+- **Production**: `https://bds33eqtv5.execute-api.us-east-1.amazonaws.com/prod` ✅ DEPLOYED
 - **Development**: `https://12c77xnz00.execute-api.us-east-1.amazonaws.com/v1`
 
 ## Authentication - DEPLOYED ✅

--- a/docs/DEPLOYMENT_PLAN.md
+++ b/docs/DEPLOYMENT_PLAN.md
@@ -53,7 +53,7 @@ This document outlines the complete deployment strategy for the Rewind podcast a
 **Frontend (.env.production):**
 
 ```
-VITE_API_BASE_URL=https://12c77xnz00.execute-api.us-east-1.amazonaws.com/v1
+VITE_API_BASE_URL=https://bds33eqtv5.execute-api.us-east-1.amazonaws.com/prod
 VITE_AWS_REGION=us-east-1
 VITE_COGNITO_USER_POOL_ID=[FROM_CDK_OUTPUT]
 VITE_COGNITO_USER_POOL_CLIENT_ID=[FROM_CDK_OUTPUT]

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -9,7 +9,7 @@ This guide provides comprehensive instructions for deploying the Rewind podcast 
 ### ✅ Production Deployment (LIVE)
 
 - **Frontend URL**: https://rewindpodcast.com (CloudFront distribution)
-- **API Base URL**: https://12c77xnz00.execute-api.us-east-1.amazonaws.com/v1
+- **API Base URL**: https://bds33eqtv5.execute-api.us-east-1.amazonaws.com/prod
 - **Authentication**: Amazon Cognito User Pool (fully configured)
 - **Database**: DynamoDB tables deployed and operational
 - **CI/CD**: Automated deployment on merge to main branch
@@ -246,7 +246,7 @@ The deployment script creates `frontend/.env.production` with these variables:
 
 ```bash
 # Auto-generated during deployment - DO NOT MODIFY
-VITE_API_BASE_URL=https://12c77xnz00.execute-api.us-east-1.amazonaws.com/v1
+VITE_API_BASE_URL=https://bds33eqtv5.execute-api.us-east-1.amazonaws.com/prod
 VITE_AWS_REGION=us-east-1
 VITE_USER_POOL_ID=us-east-1_Cw78Mapt3
 VITE_USER_POOL_CLIENT_ID=49kf2uvsl9vg08ka6o67ts41jj

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -24,7 +24,7 @@ VITE_COGNITO_DOMAIN=https://rewind-730420835413-us-east-1.auth.us-east-1.amazonc
 VITE_AWS_ACCOUNT_ID=730420835413
 
 # API Gateway URL (from RewindBackendStack deployment)
-VITE_API_URL=https://12c77xnz00.execute-api.us-east-1.amazonaws.com/v1
+VITE_API_BASE_URL=https://12c77xnz00.execute-api.us-east-1.amazonaws.com/v1
 
 # Backend Configuration (for CDK)
 DYNAMODB_TABLE_PREFIX=Rewind

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,5 +1,5 @@
 # Production environment variables
-VITE_API_BASE_URL=https://bds33eqtv5.execute-api.us-east-1.amazonaws.com/prod/
+VITE_API_BASE_URL=https://bds33eqtv5.execute-api.us-east-1.amazonaws.com/prod
 VITE_AWS_REGION=us-east-1
 VITE_USER_POOL_ID=us-east-1_jfT5M1vfA
 VITE_USER_POOL_CLIENT_ID=7viflgadalnplcvo49fmv45i3c


### PR DESCRIPTION
Fix API URL and environment variable configurations to enable search and recommendations on production.

The previous configuration had a trailing slash in the production API URL and an incorrect environment variable name (`VITE_API_URL` instead of `VITE_API_BASE_URL`) in the development environment, preventing API calls from reaching the correct endpoints. This PR also updates related documentation to reflect the correct API base URL.